### PR TITLE
Fix bad 'ssh %s' translation in lt.po

### DIFF
--- a/po/lt.po
+++ b/po/lt.po
@@ -5258,7 +5258,7 @@ msgid ""
 msgstr ""
 "Kai leidžiama prisijungti nuotoliniu būdu, nutolę naudotojai gali "
 "prisijungti naudodami saugaus apvalkalo komandą:\n"
-"<a href=\"ssh %s>ssh %s</a>"
+"<a href=\"ssh %s\">ssh %s</a>"
 
 #: ../panels/sharing/cc-sharing-panel.c:684
 #, c-format


### PR DESCRIPTION
The diff should be self-explanatory.

(And yes, I know that GNOME doesn't accept GitHub pull reqests.  I'm using GitHub as a convenient way to produce a patch file I can upload to Bugzilla.)