### PR TITLE
Added tap-to-click-description

### DIFF
--- a/panels/mouse/gnome-mouse-properties.ui
+++ b/panels/mouse/gnome-mouse-properties.ui
@@ -590,6 +590,26 @@
                                   </packing>
                                 </child>
                                 <child>
+                                  <object class="GtkLabel" id="tap-to-click-description">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="xalign">0</property>
+                                    <property name="label" translatable="yes">Enables single click and two finger right click.</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                    <attributes>
+                                      <attribute name="scale" value="0.9"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">1</property>
+                                    <property name="width">1</property>
+                                    <property name="height">1</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <object class="GtkSwitch" id="tap-to-click-switch">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>


### PR DESCRIPTION
Added tap-to-click-description as users were not clear on the what was enabled when selecting this feature. This is helpful in that the  feature does more then just enable left click it also enables two finger right click. Some users may find this relevant.