### PR TITLE
Updating "info" to "info-overview" in man page.

### DIFF
--- a/man/gnome-control-center.xml
+++ b/man/gnome-control-center.xml
@@ -115,7 +115,7 @@
                         </varlistentry>
 
                         <varlistentry>
-                                <term><option>info</option></term>
+                                <term><option>info-overview</option></term>
 
                                 <listitem><para>The info panel shows a general
                                 overview of the system configuration. It also


### PR DESCRIPTION
Somebody changed it in the panels, but forgot to update the man page.