### PR TITLE
[Translation Portuguese] Make clear when the connection is used just for resources on the remote network

### DIFF
--- a/po/pt.po
+++ b/po/pt.po
@@ -3359,7 +3359,7 @@ msgstr "Métrica"
 #: panels/network/connection-editor/ip4-page.ui:398
 #: panels/network/connection-editor/ip6-page.ui:412
 msgid "Use this connection _only for resources on its network"
-msgstr "Utilize esta ligaçã_o só para recursos na sua rede"
+msgstr "Utilize esta ligaçã_o só para os recursos na rede remota"
 
 #: panels/network/connection-editor/ip6-page.ui:27
 msgid "IPv_6 Method"


### PR DESCRIPTION
Hi,

When we use a VPN, we can use it to access all remote resource (ié use this connection for every resource) or we can use this connection for only resources on the VPN network and use other connections for resources outside the VPN remote network.

The Portuguese translation IMHO is misleading and can be improved to make clear when we just want to use this connection for the resources on the remote VPN network.

The typical usage scenario is to check this option for resources in our office and use another connection(s) (like the default connection offered by the provider) for surfing the web, etc.

An alternative could be:

```
"Utilize esta ligaçã_o só para os recursos nesta rede VPN"
```

