### PR TITLE
More options for Blank Screen Delay

### DIFF
--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -960,7 +960,7 @@ static void
 populate_blank_screen_row (HdyComboRow *combo_row)
 {
   g_autoptr (GListStore) list_store = g_list_store_new (HDY_TYPE_VALUE_OBJECT);
-  gint minutes[] = { 1, 2, 3, 4, 5, 8, 10, 12, 15 };
+  gint minutes[] = { 1, 2, 3, 4, 5, 8, 10, 12, 15, 30, 60 };
   guint i;
   g_autoptr (HdyValueObject) never_value_object = NULL;
 


### PR DESCRIPTION
I think the range of options proposed for this option does not make sense. I can't see a specific use case where a user would need its screen to blank after exactly 12 minutes. On the other hand, it was really annoying for me that the only choice I had to leave the screen open when I am working on a second computer was to choose between "15mins" and "never", both of which are not good for my use case. I think a good subdivision would be in exponential increments, similar to [1,2,5,10,15,30,60]. Anyways I only added 30 and 60 and left the other options as they were.