### PR TITLE
Fixed typo in French translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -2186,7 +2186,7 @@ msgid ""
 "This can be changed in the keyboard shortcut settings."
 msgstr ""
 "Vous pouvez basculer d’une source de saise à une autre à l’aide du "
-"raccourcis clavier %s. Pour modifier ces raccourcis clavier, allez dans les "
+"raccourci clavier %s. Pour modifier ces raccourcis clavier, allez dans les "
 "préférences clavier"
 
 #: panels/keyboard/cc-keyboard-panel.ui:17


### PR DESCRIPTION
Typo in French translation : There is a typo inside the "Keyboard" category of gnome-control-panel if the language is set to French.

"Vous pouvez basculer d’une source de saise à une autre à l’aide du " "raccourcis clavier %s.
In this sentence :
"raccourcis" is plural while "du" announces it as singular.
There is only one shortcut, so "raccourcis" needs to be singular.
Thus it should be spelled "raccourci".